### PR TITLE
Add eject player behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1132,7 +1132,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
             "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
@@ -1958,7 +1957,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -3307,7 +3305,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3398,7 +3395,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -3444,7 +3440,6 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -3538,7 +3533,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3552,7 +3546,6 @@
             "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.18",
                 "@vitest/mocker": "4.0.18",

--- a/src/gameManager.ts
+++ b/src/gameManager.ts
@@ -189,6 +189,90 @@ export function playAgain(roomId: string, playerId: string): GameRoom | null {
     return room;
 }
 
+export function ejectPlayer(
+    roomId: string,
+    hostId: string,
+    playerIdToEject: string
+): GameRoom | null {
+    const room = rooms[roomId];
+    if (!room || room.hostId !== hostId || hostId === playerIdToEject)
+        return null;
+
+    const playerIndex = room.players.findIndex((p) => p.id === playerIdToEject);
+    if (playerIndex === -1) return null;
+
+    // Remove player
+    room.players.splice(playerIndex, 1);
+
+    if (room.phase !== 'LOBBY') {
+        // If the ejected player was the impostor, game ends
+        if (room.impostorId === playerIdToEject) {
+            room.phase = 'RESULTS';
+        }
+
+        // Only handle turn/voting logic if we're not in RESULTS now (or if we were already in it)
+        if (room.phase !== 'RESULTS') {
+            const turnOrderIndex = room.turnOrder.indexOf(playerIdToEject);
+            if (turnOrderIndex !== -1) {
+                room.turnOrder.splice(turnOrderIndex, 1);
+
+                if (room.currentTurnPlayerId === playerIdToEject) {
+                    if (room.turnIndex >= room.turnOrder.length) {
+                        if (room.phase === 'DRAWING') {
+                            room.phase = 'VOTING';
+                        }
+                        room.currentTurnPlayerId = null;
+                    } else {
+                        room.currentTurnPlayerId =
+                            room.turnOrder[room.turnIndex];
+                    }
+                } else if (turnOrderIndex < room.turnIndex) {
+                    room.turnIndex--;
+                }
+            }
+
+            // Voting Cleanup
+            delete room.votes[playerIdToEject];
+            room.players.forEach((p) => {
+                if (room.votes[p.id] === playerIdToEject) {
+                    delete room.votes[p.id];
+                    p.hasVoted = false;
+                }
+            });
+
+            // Re-evaluate voting phase completion
+            if (room.phase === 'VOTING') {
+                const totalConnected = room.players.filter(
+                    (p) => p.isConnected
+                ).length;
+                const totalVotesCast = Object.keys(room.votes).length;
+
+                if (totalVotesCast >= totalConnected && totalConnected > 0) {
+                    room.phase = 'RESULTS';
+                }
+            }
+
+            // Enforce minimum player count
+            if (room.players.length < 3 && room.phase !== 'RESULTS') {
+                room.phase = 'LOBBY';
+                room.impostorId = null;
+                room.secretWord = null;
+                room.secretCategory = null;
+                room.currentTurnPlayerId = null;
+                room.turnOrder = [];
+                room.turnIndex = 0;
+                room.votes = {};
+                room.canvasStrokes = [];
+                room.players.forEach((p) => {
+                    p.hasVoted = false;
+                });
+            }
+        }
+    }
+
+    return room;
+}
+
 export function nextRound(roomId: string, playerId: string): GameRoom | null {
     const room = rooms[roomId];
     if (!room || room.hostId !== playerId) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
     playAgain,
     clearCanvas,
     nextRound,
+    ejectPlayer,
 } from './gameManager';
 import { Player, StrokeData } from './types';
 
@@ -273,6 +274,25 @@ io.on('connection', (socket: Socket) => {
         if (!roomId) return;
         const room = nextRound(roomId, user.userId);
         if (room) {
+            io.to(roomId).emit('gameStateUpdate', getSanitizedRoomState(room));
+        }
+    });
+
+    socket.on('ejectPlayer', ({ playerIdToEject }) => {
+        const user = (socket as any).user;
+        const roomId = socketToRoom[socket.id];
+        if (!roomId) return;
+        const room = ejectPlayer(roomId, user.userId, playerIdToEject);
+        if (room) {
+            const ejectedSocketId = userIdToSocketId[playerIdToEject];
+            if (ejectedSocketId) {
+                const ejectedSocket = io.sockets.sockets.get(ejectedSocketId);
+                if (ejectedSocket) {
+                    ejectedSocket.emit('ejected');
+                    ejectedSocket.leave(roomId);
+                }
+                delete socketToRoom[ejectedSocketId];
+            }
             io.to(roomId).emit('gameStateUpdate', getSanitizedRoomState(room));
         }
     });

--- a/src/tests/gameManager.test.ts
+++ b/src/tests/gameManager.test.ts
@@ -12,6 +12,7 @@ import {
     castVote,
     playAgain,
     nextRound,
+    ejectPlayer,
 } from '../gameManager';
 import { Player, StrokeData } from '../types';
 import { MAX_NUM_PLAYERS_PER_ROOM } from '../constants';
@@ -360,6 +361,175 @@ describe('gameManager', () => {
 
         it('should return null for invalid room', () => {
             expect(nextRound('invalid', 'host1')).toBeNull();
+        });
+    });
+
+    describe('ejectPlayer', () => {
+        it('should eject a player in LOBBY phase', () => {
+            createRoom('room-eject-lobby', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            joinRoom('room-eject-lobby', p1);
+            joinRoom('room-eject-lobby', p2);
+
+            const result = ejectPlayer('room-eject-lobby', 'host1', 'p1');
+            expect(result).not.toBeNull();
+            expect(result!.players.length).toBe(1);
+            expect(result!.players[0].id).toBe('p2');
+        });
+
+        it('should eject current drawer in DRAWING phase and advance turn', () => {
+            const room = createRoom('room-eject-drawing', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            const p4 = createPlayer('p4', 'Dan');
+            joinRoom('room-eject-drawing', p1);
+            joinRoom('room-eject-drawing', p2);
+            joinRoom('room-eject-drawing', p3);
+            joinRoom('room-eject-drawing', p4);
+
+            room.phase = 'DRAWING';
+            room.turnOrder = ['p1', 'p2', 'p3', 'p4'];
+            room.turnIndex = 0;
+            room.currentTurnPlayerId = 'p1';
+
+            const result = ejectPlayer('room-eject-drawing', 'host1', 'p1');
+            expect(result!.currentTurnPlayerId).toBe('p2');
+            expect(result!.turnOrder).toEqual(['p2', 'p3', 'p4']);
+            expect(result!.turnIndex).toBe(0);
+        });
+
+        it('should eject last drawer in DRAWING phase and transition to VOTING', () => {
+            const room = createRoom('room-eject-last', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            const p4 = createPlayer('p4', 'Dan');
+            joinRoom('room-eject-last', p1);
+            joinRoom('room-eject-last', p2);
+            joinRoom('room-eject-last', p3);
+            joinRoom('room-eject-last', p4);
+
+            room.phase = 'DRAWING';
+            room.turnOrder = ['p1', 'p2', 'p3', 'p4'];
+            room.turnIndex = 3;
+            room.currentTurnPlayerId = 'p4';
+
+            const result = ejectPlayer('room-eject-last', 'host1', 'p4');
+            expect(result!.phase).toBe('VOTING');
+            expect(result!.currentTurnPlayerId).toBeNull();
+            expect(result!.turnOrder).toEqual(['p1', 'p2', 'p3']);
+        });
+
+        it('should eject a non-drawer in DRAWING phase and adjust turnIndex if needed', () => {
+            const room = createRoom('room-eject-nondrawer', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            const p4 = createPlayer('p4', 'Dan');
+            joinRoom('room-eject-nondrawer', p1);
+            joinRoom('room-eject-nondrawer', p2);
+            joinRoom('room-eject-nondrawer', p3);
+            joinRoom('room-eject-nondrawer', p4);
+
+            room.phase = 'DRAWING';
+            room.turnOrder = ['p1', 'p2', 'p3', 'p4'];
+            room.turnIndex = 1;
+            room.currentTurnPlayerId = 'p2';
+
+            const result = ejectPlayer('room-eject-nondrawer', 'host1', 'p1');
+            expect(result!.currentTurnPlayerId).toBe('p2');
+            expect(result!.turnOrder).toEqual(['p2', 'p3', 'p4']);
+            expect(result!.turnIndex).toBe(0);
+        });
+
+        it('should eject impostor and transition to RESULTS', () => {
+            const room = createRoom('room-eject-impostor', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            joinRoom('room-eject-impostor', p1);
+            joinRoom('room-eject-impostor', p2);
+            joinRoom('room-eject-impostor', p3);
+
+            room.phase = 'DRAWING';
+            room.impostorId = 'p1';
+
+            const result = ejectPlayer('room-eject-impostor', 'host1', 'p1');
+            expect(result!.phase).toBe('RESULTS');
+        });
+
+        it('should transition to RESULTS even if < 3 players if VOTING completes', () => {
+            const room = createRoom('room-eject-voting-small', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            joinRoom('room-eject-voting-small', p1);
+            joinRoom('room-eject-voting-small', p2);
+            joinRoom('room-eject-voting-small', p3);
+
+            room.phase = 'VOTING';
+            room.votes = {
+                p1: 'p3',
+                p3: 'p1'
+            };
+            room.players.find(p => p.id === 'p1')!.hasVoted = true;
+            room.players.find(p => p.id === 'p3')!.hasVoted = true;
+            room.players.forEach(p => p.isConnected = true);
+
+            // Alice(p1, host, voted), Bob(p2, connected, NOT voted), Charlie(p3, voted).
+            // Eject Bob(p2).
+            const result = ejectPlayer('room-eject-voting-small', 'host1', 'p2');
+            expect(result).not.toBeNull();
+            expect(result!.phase).toBe('RESULTS');
+            expect(result!.players.length).toBe(2);
+        });
+
+        it('should revert to LOBBY if players fall below 3 and not in RESULTS', () => {
+            const room = createRoom('room-eject-under3', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            joinRoom('room-eject-under3', p1);
+            joinRoom('room-eject-under3', p2);
+            joinRoom('room-eject-under3', p3);
+
+            room.phase = 'DRAWING';
+
+            const result = ejectPlayer('room-eject-under3', 'host1', 'p1');
+            expect(result!.phase).toBe('LOBBY');
+            expect(result!.players.length).toBe(2);
+        });
+
+        it('should reset votes cast FOR the ejected player', () => {
+            const room = createRoom('room-eject-votedfor', 'host1');
+            const p1 = createPlayer('p1', 'Alice');
+            const p2 = createPlayer('p2', 'Bob');
+            const p3 = createPlayer('p3', 'Charlie');
+            const p4 = createPlayer('p4', 'Dan');
+            joinRoom('room-eject-votedfor', p1);
+            joinRoom('room-eject-votedfor', p2);
+            joinRoom('room-eject-votedfor', p3);
+            joinRoom('room-eject-votedfor', p4);
+
+            room.phase = 'VOTING';
+            room.votes = {
+                p1: 'p2',
+                p3: 'p2',
+                p4: 'p1'
+            };
+            room.players.find(p => p.id === 'p1')!.hasVoted = true;
+            room.players.find(p => p.id === 'p3')!.hasVoted = true;
+            room.players.find(p => p.id === 'p4')!.hasVoted = true;
+
+            const result = ejectPlayer('room-eject-votedfor', 'host1', 'p2');
+            expect(result!.votes['p1']).toBeUndefined();
+            expect(result!.votes['p3']).toBeUndefined();
+            expect(result!.votes['p4']).toBe('p1');
+            expect(result!.players.find(p => p.id === 'p1')!.hasVoted).toBe(false);
+            expect(result!.players.find(p => p.id === 'p3')!.hasVoted).toBe(false);
+            expect(result!.players.find(p => p.id === 'p4')!.hasVoted).toBe(true);
         });
     });
 });


### PR DESCRIPTION
This PR adds the ability for game hosts to eject players from a room. The backend logic handles the following:
- Validates that only the host can eject others and cannot eject themselves.
- If in a game, it removes the player from the turn order and advances the turn if the current drawer is ejected.
- If the impostor is ejected, the game transitions to the RESULTS phase.
- If player count falls below 3, the game reverts to the LOBBY phase (unless already in RESULTS).
- Cleans up votes cast by and for the ejected player, potentially completing the VOTING phase early.
- Properly disconnects the ejected player's socket from the room.

Extensive unit tests were added to `gameManager.test.ts` to verify these behaviors.

Fixes #20

---
*PR created automatically by Jules for task [15646156212238439926](https://jules.google.com/task/15646156212238439926) started by @jorbush*